### PR TITLE
Fix generation crash for empty lists

### DIFF
--- a/Sources/Meta/PlainCode.swift
+++ b/Sources/Meta/PlainCode.swift
@@ -56,6 +56,7 @@ extension MetaCode {
     }
 
     public var swiftString: String {
+        guard metaElements.isEmpty == false else { return String() }
         var string = metaElements
             .map { $0.swiftString }
             .indented(indentation)


### PR DESCRIPTION
Don't let MetaCode crash if it's initialised with an empty array of elements