### PR TITLE
Allow for raw switch cases

### DIFF
--- a/Sources/Meta/Switch.swift
+++ b/Sources/Meta/Switch.swift
@@ -31,6 +31,7 @@ extension SwitchCaseVariable: VariableValue {}
 public enum SwitchCaseName: Hashable, MetaSwiftConvertible {
     case `default`
     case custom(String)
+    case nonEnum(String)
 }
 
 public struct SwitchCase: Hashable, MetaSwiftConvertible {
@@ -142,6 +143,8 @@ extension SwitchCaseName {
             return "default"
         case .custom(let name):
             return "case .\(name)"
+        case .nonEnum(let name):
+            return "case \(name)"
         }
     }
 }

--- a/Sources/Meta/Switch.swift
+++ b/Sources/Meta/Switch.swift
@@ -31,7 +31,7 @@ extension SwitchCaseVariable: VariableValue {}
 public enum SwitchCaseName: Hashable, MetaSwiftConvertible {
     case `default`
     case custom(String)
-    case nonEnum(String)
+    case raw(String)
 }
 
 public struct SwitchCase: Hashable, MetaSwiftConvertible {
@@ -143,7 +143,7 @@ extension SwitchCaseName {
             return "default"
         case .custom(let name):
             return "case .\(name)"
-        case .nonEnum(let name):
+        case .raw(let name):
             return "case \(name)"
         }
     }

--- a/Tests/MetaTests/FileTests.swift
+++ b/Tests/MetaTests/FileTests.swift
@@ -94,7 +94,7 @@ final class FileTests: XCTestCase {
         let barID = TypeIdentifier(name: "Bar")
         let bar = Type(identifier: barID)
             .adding(inheritedType: .string)
-            .with(kind: .enum)
+            .with(kind: .enum(indirect: false))
             .with(accessLevel: .public)
             .adding(member: Case(name: "hello").with(value: .string("Hello")))
             .adding(member: Case(name: "world"))


### PR DESCRIPTION
This PR adds support to define switch cases like this:
```swift
switch someString {
    case "Foo": print("foo")
    case "Bar": print("bar")
    default: print(someString)
}
```
or
```swift
switch someInteger {
    case 0: print("zero")
    default: print(someInteger)
}
```
I also fixed a outdated test.